### PR TITLE
Add credentials.yml file

### DIFF
--- a/kedro-exercises/spaceflight/conf/base/credentials.yml
+++ b/kedro-exercises/spaceflight/conf/base/credentials.yml
@@ -1,0 +1,18 @@
+
+# Here you can define credentials for different data sets and environment.
+#
+# THIS FILE MUST BE PLACED IN `conf/local`. DO NOT PUSH THIS FILE TO GitHub.
+#
+# Example:
+#
+# dev_s3:
+#     aws_access_key_id: token
+#     aws_secret_access_key: key
+#
+# prod_s3:
+#     aws_access_key_id: token
+#     aws_secret_access_key: key
+#
+# dev_sql:
+#     username: admin
+#     password: admin


### PR DESCRIPTION
@921kiyo pointed out that we explain credential management in the tutorial docs: https://github.com/quantumblacklabs/kedro-training/blob/90a74d43fb99e8127836a651189daa521a268ad8/docs/04_new_project.md#credentials-management 

So it makes sense to add the file to the tutorial template. 