### PR TITLE
Fix example in 06_jupyter-notebook-workflow

### DIFF
--- a/docs/06_jupyter-notebook-workflow.md
+++ b/docs/06_jupyter-notebook-workflow.md
@@ -69,8 +69,10 @@ Next, you need to reload Kedro variables by calling `%reload_kedro` line magic i
 Finally, you can save the data by executing the following command:
 
 ```python
+import pandas
 my_dict = {"key1": "some_value", "key2": None}
-context.catalog.save("my_dataset", my_dict)
+df = pandas.DataFrame([my_dict])
+context.catalog.save("my_dataset", df)
 ```
 
 ### Using parameters


### PR DESCRIPTION
Fixes `context.catalog.save()` example in `docs/06_jupyter-notebook-workflow.md`.

Looks like the example passes a `dict`, but `pandas.JSONDataSet` expects a `pandas.DataFrame`


## Steps to reproduce
```python
my_dict = {"key1": "some_value", "key2": None}
context.catalog.save("my_dataset", my_dict)
```

## Expected
```
# no errors, dataset saves successfully
```

## Actual
```
DataSetError: Failed while saving data to data set JSONDataSet(filepath=/Users/josephhaaga/Documents/tmp/testing/data/01_raw/my_dataset.json, load_args={}, protocol=file, save_args={}).
'dict' object has no attribute 'to_json'
```