### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Description
+<!-- Why was this PR created? -->
+
+## Development notes
+<!-- What have you changed, and how has this been tested? -->
+
+## Checklist
+
+- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
+- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
+- [ ] Updated the documentation to reflect the code changes
+- [ ] Added tests to cover my changes


### PR DESCRIPTION
While removing the "Notice" from the PR templates in the other "kedro-" repos I found that we didn't have a template for this repo yet.